### PR TITLE
Use port env var so the callback link is valid for local development

### DIFF
--- a/app/(auth-pages)/login/page.tsx
+++ b/app/(auth-pages)/login/page.tsx
@@ -35,7 +35,7 @@ export default function Login({
 
     const defaultUrl = process.env.VERCEL_URL
       ? `https://${process.env.VERCEL_URL}`
-      : 'http://localhost:3000'
+      : `http://localhost:${process.env.PORT || 3000}`;
 
     const supabase = createClient()
 


### PR DESCRIPTION
This is really cool!

This is just a minor tweak so that the callback url in the login email uses the correct port when running locally.